### PR TITLE
Release v2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+### V2.1.1
+
+- Fixed vulnerability CVE-2021-44228
+- Update to log4j version 2.15.0
+
 ### V2.1
 
 - Release for APEX 2

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ mvn package
 ```
 
 The compiled _jar_ file will be located in the **target** folder
-+ java-apex-api-security-<version>-SNAPSHOT.jar
-+ java-apex-api-security-<version>-SNAPSHOT-jar-with-dependencies.jar (this includes log4j libraries)
++ java-apex-api-security-<version>.jar
++ java-apex-api-security-<version>-jar-with-dependencies.jar (this includes log4j libraries)
 
 Import this jar file into your java classpath to use the utility class
 
@@ -64,7 +64,7 @@ mvn install
 <dependency>
     <groupId>com.api.util</groupId>
     <artifactId>ApiSecurity</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.1.1</version>
 </dependency>
 ```
  
@@ -76,12 +76,12 @@ mvn install
 <dependency>
 	<groupId>org.apache.logging.log4j</groupId>
 	<artifactId>log4j-api</artifactId>
-	<version>2.14.1</version>
+	<version>2.15.0</version>
 </dependency>
 <dependency>
 	<groupId>org.apache.logging.log4j</groupId>
 	<artifactId>log4j-core</artifactId>
-	<version>2.14.1</version>
+	<version>2.15.0</version>
 </dependency>
 ```
 
@@ -125,7 +125,7 @@ gradle test jacocoTestReport
 ```
 
 The compiled _jar_ file will be located in the **build/libs** folder
-+ java-apex-api-security-2.0.0-SNAPSHOT.jar
++ java-apex-api-security-2.1.1.jar
 
 Import this jar into your java classpath to use the utility class
 
@@ -140,7 +140,7 @@ repositories {
     mavenLocal()
 }
 dependencies {
-    compile group: 'com.api.util', name: 'ApiSecurity', version: '2.0.0-SNAPSHOT'
+    compile group: 'com.api.util', name: 'ApiSecurity', version: '2.1.1'
 }
 	
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 
-version '2.1.0'
+version '2.1.1'
 
 tasks.withType(JavaCompile) {
     options.encoding = "UTF-8"
@@ -20,8 +20,8 @@ dependencies {
     
     //gradle 4.0
     compile group: 'commons-lang', name: 'commons-lang', version: '2.4'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.14.1'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.14.1'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.15.0'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.15.0'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.10.5.1'
     compile group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
     compile group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: '1.69'

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.api.util</groupId>
   <artifactId>ApiSecurity</artifactId>
-  <version>2.1.0</version>
+  <version>2.1.1</version>
   <build>
     <plugins>
       <plugin>
@@ -80,12 +80,12 @@
   	<dependency>
 		    <groupId>org.apache.logging.log4j</groupId>
 		    <artifactId>log4j-api</artifactId>
-		    <version>2.14.1</version>
+		    <version>2.15.0</version>
 	</dependency>
   	<dependency>
 		    <groupId>org.apache.logging.log4j</groupId>
 		    <artifactId>log4j-core</artifactId>
-		    <version>2.14.1</version>
+		    <version>2.15.0</version>
 	</dependency>
   	<dependency>
             <groupId>commons-lang</groupId>

--- a/src/main/java/com/api/util/ApiSecurity/ApiSigning.java
+++ b/src/main/java/com/api/util/ApiSecurity/ApiSigning.java
@@ -12,6 +12,9 @@ import org.bouncycastle.openssl.jcajce.JceOpenSSLPKCS8DecryptorProviderBuilder;
 import org.bouncycastle.openssl.jcajce.JcePEMDecryptorProviderBuilder;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.bouncycastle.operator.InputDecryptorProvider;
+import org.bouncycastle.pkcs.PKCS8EncryptedPrivateKeyInfo;
+
 
 import org.bouncycastle.operator.InputDecryptorProvider;
 import org.bouncycastle.pkcs.PKCS8EncryptedPrivateKeyInfo;
@@ -612,6 +615,7 @@ public class ApiSigning {
                 authPrefix, signatureMethod, appId, urlPath, httpMethod, nonce, timestamp, version);
 
         String baseString = null;
+
 
         try {
             authPrefix = authPrefix.toLowerCase();


### PR DESCRIPTION
# Description

fixes CVE-2021-44228, updated log4j to 2.15.0.

Fixes # (issue number)

## Type of change

Please delete options that are not relevant.

- [x] Security patch

